### PR TITLE
Fix packaging linting errors raised by Grafana plugins check webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This datasource lets you to use the Alertmanager's API of Prometheus to create dashboards in Grafana.
 
-![Overview](images/overview.png)
+![Overview](https://raw.githubusercontent.com/camptocamp/grafana-prometheus-alertmanager-datasource/master/images/overview.png)
 
 # Usage
 
@@ -37,7 +37,7 @@ Whether the alerts gathered should be silenced.
 
 Whether the alerts gathered should be inhibited.
 
-![Parameters](images/table.png)
+![Parameters](https://raw.githubusercontent.com/camptocamp/grafana-prometheus-alertmanager-datasource/master/images/table.png)
 
 # Development Setup
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -2,7 +2,7 @@
 
 This datasource lets you to use the Alertmanager's API of Prometheus to create dashboards in Grafana.
 
-![Overview](images/overview.png)
+![Overview](https://raw.githubusercontent.com/camptocamp/grafana-prometheus-alertmanager-datasource/master/images/overview.png)
 
 # Usage
 
@@ -37,7 +37,7 @@ Whether the alerts gathered should be silenced.
 
 Whether the alerts gathered should be inhibited.
 
-![Parameters](images/table.png)
+![Parameters](https://raw.githubusercontent.com/camptocamp/grafana-prometheus-alertmanager-datasource/master/images/table.png)
 
 # Development Setup
 

--- a/dist/plugin.json
+++ b/dist/plugin.json
@@ -1,11 +1,12 @@
 {
   "name": "Prometheus AlertManager",
-  "id": "camptocamp-prometheus-alertmanager-datasource",
+  "id": "camptocamp-alertmanager-datasource",
   "type": "datasource",
   "metrics": true,
   "annotations": false,
   "info": {
     "description": "Prometheus AlertManager datasource",
+    "keywords": ["prometheus", "alertmanager"],
     "author": {
       "name": "Camptocamp",
       "url": "https://camptocamp.com"
@@ -18,12 +19,16 @@
       {"name": "GitHub", "url": "https://github.com/camptocamp/grafana-prometheus-alertmanager-datasource"},
       {"name": "MIT License", "url": "https://github.com/camptocamp/grafana-prometheus-alertmanager-datasource/blob/master/LICENSE"}
     ],
+    "screenshots": [
+      {"name": "Dashboard", "path": "images/overview.png"},
+      {"name": "QueryEditor", "path": "images/table.png"}
+    ],
     "version": "1.0.0",
-    "updated": "2021-02-12"
+    "updated": "2021-02-13"
   },
 
   "dependencies": {
-    "grafanaVersion": "7.1.x",
+    "grafanaDependency": "7.1.x",
     "plugins": [ ]
   }
 }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,11 +1,12 @@
 {
   "name": "Prometheus AlertManager",
-  "id": "camptocamp-prometheus-alertmanager-datasource",
+  "id": "camptocamp-alertmanager-datasource",
   "type": "datasource",
   "metrics": true,
   "annotations": false,
   "info": {
     "description": "Prometheus AlertManager datasource",
+    "keywords": ["prometheus", "alertmanager"],
     "author": {
       "name": "Camptocamp",
       "url": "https://camptocamp.com"
@@ -18,12 +19,16 @@
       {"name": "GitHub", "url": "https://github.com/camptocamp/grafana-prometheus-alertmanager-datasource"},
       {"name": "MIT License", "url": "https://github.com/camptocamp/grafana-prometheus-alertmanager-datasource/blob/master/LICENSE"}
     ],
+    "screenshots": [
+      {"name": "Dashboard", "path": "images/overview.png"},
+      {"name": "QueryEditor", "path": "images/table.png"}
+    ],
     "version": "%VERSION%",
     "updated": "%TODAY%"
   },
 
   "dependencies": {
-    "grafanaVersion": "7.1.x",
+    "grafanaDependency": "7.1.x",
     "plugins": [ ]
   }
 }


### PR DESCRIPTION
Fixes various linting errors raised by Grafana plugin submission checks [web app](https://grafana-plugins-web-vgmmyppaka-lz.a.run.app/).

After following the instructions to [package a plugin](https://grafana.com/docs/grafana/latest/developers/plugins/package-a-plugin/) and applying the changes in this PR, the only outstanding error is `Unsigned plugin` and the only outstanding warning is `README contains developer jargon`:

NOTE: In other to match the required ID regex for the plugin I had to change the id to `camptocamp-alertmanager-datasource`. That may or may not be an issue for you.

The errors and warnings the app gave before these changes were:

### Errors:

**Invalid ID format**
```
A plugin ID must have the form <username>-<name>-<type> or <username>-<type>, where
username is the Grafana.com account that owns the plugin name is the name of the plugintype
is the type of the plugin and must be one of panel, datasource, or app
```

**Invalid plugin.json**
```
id: Does not match pattern '^[0-9a-z]+-([0-9a-z]+-)?(app|panel|datasource)$'
For more information, refer to the reference documentation.
```

**Invalid plugin.json**
```
info: keywords is required
For more information, refer to the reference documentation.
```

**Invalid plugin.json**
```
dependencies: grafanaDependency is required
For more information, refer to the reference documentation.
```

**Unsigned plugin**
```
Since Grafana 7.3, we require all plugins to be signed.
For more information on how to sign your plugin, refer to Sign a plugin.
```

**README contains a relative link**
```
Relative links are not supported by Grafana and results in broken links wherever we
display the README. Please convert images/overview.png into an absolute link.
```

**README contains a relative link**
```
Relative links are not supported by Grafana and results in broken links wherever we
display the README. Please convert images/table.png into an absolute link.
```

### Warnings:

**Plugin is missing screenshots**
```
Screenshots help users understand what your plugin does, and how to use it.
Consider providing screenshots to your plugin by adding them under info.screenshots
in the plugin.json file. For more information, refer to the reference documentation.
```

**README contains developer jargon**
```
Grafana uses the README within the application to help users understand how to
use your plugin. Instructions for building and testing the plugin can be confusing for the
end user. You can maintain separate instructions for users and developers by replacing the
README in the dist directory with the user documentation.
```