### PR TITLE
fixing plugin validation

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -28,7 +28,7 @@
   },
 
   "dependencies": {
-    "grafanaDependency": ">= 7.1.0",
+    "grafanaDependency": ">=7.1.0",
     "plugins": [ ]
   }
 }


### PR DESCRIPTION
node-semver doesnt allow for spaces in version strings, which is detected by the grafana plugin validator. This will fix one of validation failure as mentioned in grafana/grafana-plugin-repository/868