### PR TITLE
Merge labels and annotations from all alerts, not only from the first one

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -91,12 +91,8 @@ export class AlertmanagerDataSource extends DataSourceApi<CustomQuery, GenericOp
     const fields = [{ name: 'Time', type: FieldType.time }];
 
     if (data.length > 0) {
-      const annotations: string[] = data
-        .map((alert: any) => Object.keys(alert.annotations))
-        .reduce((data: string[][]) => data.flat());
-      const labels: string[] = data
-        .map((alert: any) => Object.keys(alert.labels))
-        .reduce((data: string[][]) => data.flat());
+      const annotations: string[] = data.map((alert: any) => Object.keys(alert.annotations)).flat();
+      const labels: string[] = data.map((alert: any) => Object.keys(alert.labels)).flat();
       const alertstatus: string[] = ['alertstatus', 'alertstatus_code'];
       const attributes: string[] = [...new Set([...annotations, ...labels, ...alertstatus])];
 


### PR DESCRIPTION
This PR is intended to fix the issue that is mentioned in this issue - https://github.com/camptocamp/grafana-prometheus-alertmanager-datasource/issues/115