### PR TITLE
refactor: rewrite plugin to add multiples queries support

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -1,15 +1,18 @@
+import { EditorQuery, scenarios } from './types';
 import {
+  DataQueryRequest,
   DataQueryResponse,
   DataSourceApi,
   DataSourceInstanceSettings,
   FieldType,
   MutableDataFrame,
 } from '@grafana/data';
-import { getBackendSrv, getTemplateSrv } from '@grafana/runtime';
-import { GenericOptions, CustomQuery, QueryRequest, defaultQuery } from './types';
+import { getBackendSrv } from '@grafana/runtime';
+import { alertsQueryBuilder, retrieveAlertsData } from './alerts/query';
+import { CustomAlertQuery, GenericOptions } from './alerts/types';
 import { firstValueFrom } from 'rxjs';
 
-export class AlertmanagerDataSource extends DataSourceApi<CustomQuery, GenericOptions> {
+export class AlertmanagerDataSource extends DataSourceApi<EditorQuery, GenericOptions> {
   url: string;
   withCredentials: boolean;
   headers: any;
@@ -26,36 +29,29 @@ export class AlertmanagerDataSource extends DataSourceApi<CustomQuery, GenericOp
     }
   }
 
-  async query(options: QueryRequest): Promise<DataQueryResponse> {
+  async query(options: DataQueryRequest<EditorQuery>): Promise<DataQueryResponse> {
+    let url: string;
+    let params: string[];
     const promises = options.targets.map((query) => {
-      query = { ...defaultQuery, ...query };
       if (query.hide) {
         return Promise.resolve(new MutableDataFrame());
       }
 
-      let params: string[] = [];
-      const queryActive = query.active ? 'true' : 'false';
-      const querySilenced = query.silenced ? 'true' : 'false';
-      const queryInhibited = query.inhibited ? 'true' : 'false';
-      params.push(`active=${queryActive}`);
-      params.push(`silenced=${querySilenced}`);
-      params.push(`inhibited=${queryInhibited}`);
-      if (query.receiver !== undefined && query.receiver.length > 0) {
-        params.push(`receiver=${query.receiver}`);
-      }
-      if (query.filters !== undefined && query.filters.length > 0) {
-        query.filters = getTemplateSrv().replace(query.filters, options.scopedVars, this.interpolateQueryExpr);
-        query.filters.split(',').forEach((value) => {
-          params.push(`filter=${encodeURIComponent(value)}`);
-        });
+      switch (query.scenario) {
+        case scenarios.alerts:
+          params = alertsQueryBuilder(this, query as CustomAlertQuery, options);
+          url = `${this.url}/api/v2/alerts?${params.join('&')}`;
+          break;
+        default:
+          return new Promise(() => null);
       }
 
       const request = this.doRequest({
-        url: `${this.url}/api/v2/alerts?${params.join('&')}`,
+        url: url,
         method: 'GET',
-      }).then((request) => firstValueFrom(request));
+      }).then((request: any) => firstValueFrom(request));
 
-      return request.then((data: any) => this.retrieveData(query, data));
+      return request.then((data: any) => retrieveAlertsData(query, data));
     });
 
     return Promise.all(promises).then((data) => {

--- a/src/alerts/QueryEditor.tsx
+++ b/src/alerts/QueryEditor.tsx
@@ -1,0 +1,76 @@
+import { LegacyForms } from '@grafana/ui';
+import React, { ChangeEvent } from 'react';
+import { CustomAlertQuery, defaultAlertQuery } from './types';
+import { ScenarioProps } from 'types';
+import { defaults } from 'lodash';
+
+const { FormField, Switch } = LegacyForms;
+
+const AlertsQueryEditor = (props: ScenarioProps<CustomAlertQuery>) => {
+  const { onChange, onRunQuery } = props;
+  const query = defaults(props.query, defaultAlertQuery);
+
+  const onReceiverChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange({ ...query, receiver: event.target.value } as CustomAlertQuery);
+    onRunQuery();
+  };
+
+  const onFiltersChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange({ ...query, filters: event.target.value } as CustomAlertQuery);
+    onRunQuery();
+  };
+
+  const onActiveChange = () => {
+    query.active = !query.active;
+    onChange({ ...query });
+    onRunQuery();
+  };
+
+  const onSilencedChange = () => {
+    query.silenced = !query.silenced;
+    onChange({ ...query });
+    onRunQuery();
+  };
+
+  const onInhibitedChange = () => {
+    query.inhibited = !query.inhibited;
+    onChange({ ...query });
+    onRunQuery();
+  };
+
+  return (
+    <>
+      <div className="gf-form-inline">
+        <div className="gf-form">
+          <FormField
+            value={query.receiver}
+            inputWidth={10}
+            onChange={onReceiverChange}
+            labelWidth={5}
+            label="Receiver"
+          />
+        </div>
+        <div className="gf-form">
+          <FormField
+            value={query.filters}
+            inputWidth={30}
+            onChange={onFiltersChange}
+            labelWidth={15}
+            label="Filters (comma separated key=value)"
+          />
+        </div>
+        <div className="gf-form">
+          <Switch label="Active" checked={query.active!} onChange={onActiveChange} />
+        </div>
+        <div className="gf-form">
+          <Switch label="Silenced" checked={query.silenced!} onChange={onSilencedChange} />
+        </div>
+        <div className="gf-form">
+          <Switch label="Inhibited" checked={query.inhibited!} onChange={onInhibitedChange} />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default AlertsQueryEditor;

--- a/src/alerts/query.ts
+++ b/src/alerts/query.ts
@@ -1,0 +1,89 @@
+import { CustomAlertQuery } from './types';
+import { DataQueryRequest, FieldType, MutableDataFrame } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
+import { EditorQuery } from 'types';
+import { AlertmanagerDataSource } from 'DataSource';
+
+export function alertsQueryBuilder(
+  datasource: AlertmanagerDataSource,
+  query: CustomAlertQuery,
+  options: DataQueryRequest<EditorQuery>
+): string[] {
+  let params: string[] = [];
+  const queryActive = query.active ? 'true' : 'false';
+  const querySilenced = query.silenced ? 'true' : 'false';
+  const queryInhibited = query.inhibited ? 'true' : 'false';
+  params.push(`active=${queryActive}`);
+  params.push(`silenced=${querySilenced}`);
+  params.push(`inhibited=${queryInhibited}`);
+  if (query.receiver !== undefined && query.receiver.length > 0) {
+    params.push(`receiver=${query.receiver}`);
+  }
+  if (query.filters !== undefined && query.filters.length > 0) {
+    query.filters = getTemplateSrv().replace(query.filters, options.scopedVars, datasource.interpolateQueryExpr);
+    query.filters.split(',').forEach((value: any) => {
+      params.push(`filter=${encodeURIComponent(value)}`);
+    });
+  }
+
+  return params;
+}
+
+export function retrieveAlertsData(query: any, data: any): Promise<MutableDataFrame> {
+  const frame = buildAlertDataFrame(query.refId, data.data);
+  data.data.forEach((alert: any) => {
+    const row: string[] = parseAlertAttributes(alert, frame.fields);
+    frame.appendRow(row);
+  });
+  return Promise.resolve(frame);
+}
+
+function buildAlertDataFrame(refId: string, data: any): MutableDataFrame {
+  const fields = [
+    { name: 'Time', type: FieldType.time },
+    { name: 'SeverityValue', type: FieldType.number },
+  ];
+
+  if (data.length > 0) {
+    const annotations: string[] = data.map((alert: any) => Object.keys(alert.annotations)).flat();
+    const labels: string[] = data.map((alert: any) => Object.keys(alert.labels)).flat();
+    const alertstatus: string[] = ['alertstatus', 'alertstatus_code'];
+    const attributes: string[] = [...new Set([...annotations, ...labels, ...alertstatus])];
+
+    attributes.forEach((attribute: string) => {
+      fields.push({
+        name: attribute,
+        type: FieldType.string,
+      });
+    });
+  }
+
+  const frame = new MutableDataFrame({
+    refId: refId,
+    fields: fields,
+  });
+  return frame;
+}
+
+function parseAlertAttributes(alert: any, fields: any[]): string[] {
+  let severityValue = 4;
+  switch (alert.labels['severity']) {
+    case 'critical':
+      severityValue = 1;
+      break;
+    case 'warning':
+      severityValue = 2;
+      break;
+    case 'info':
+      severityValue = 3;
+      break;
+    default:
+      break;
+  }
+
+  const row: string[] = [alert.startsAt, severityValue];
+  fields.slice(2).forEach((element: any) => {
+    row.push(alert.annotations[element.name] || alert.labels[element.name] || '');
+  });
+  return row;
+}

--- a/src/alerts/types.ts
+++ b/src/alerts/types.ts
@@ -1,0 +1,21 @@
+import { DataQueryRequest, DataSourceJsonData } from '@grafana/data';
+import { EditorQuery } from '../types';
+
+export interface QueryRequest extends DataQueryRequest<CustomAlertQuery> {
+  adhocFilters?: any[];
+}
+
+export interface CustomAlertQuery extends EditorQuery {
+  target?: string;
+  receiver?: string;
+  filters?: string;
+  active?: boolean;
+  silenced?: boolean;
+  inhibited?: boolean;
+}
+
+export const defaultAlertQuery: Partial<CustomAlertQuery> = {
+  active: true,
+};
+
+export interface GenericOptions extends DataSourceJsonData {}

--- a/src/components/FormSelect.tsx
+++ b/src/components/FormSelect.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { InlineFormLabel, Select, PopoverContent, Checkbox } from '@grafana/ui';
+import FormWrapper from './FormWrapper';
+import { SelectableValue } from '@grafana/data';
+import { SelectCommonProps } from '@grafana/ui/components/Select/types';
+
+export type NotOptionsType = Partial<{
+  onNotChange(e: any): any;
+  showNotCheckbox: boolean;
+  notCheckboxValue: boolean;
+  notCheckboxLabel: string;
+  notCheckboxDisabled: boolean;
+}>;
+
+export interface FormSelectProps extends SelectCommonProps<any> {
+  label: string;
+  name?: string;
+  value: SelectableValue | string;
+  options: any;
+  queryKeyword?: boolean;
+  disabled?: boolean;
+  defaultValue?: SelectableValue;
+  noOptionsMessage?: string;
+  searchable?: boolean | true;
+  labelWidth?: number | 14;
+  inputWidth?: number | 30;
+  placeholder?: string | '-';
+  tooltip?: PopoverContent;
+  className?: string;
+  isLoading?: boolean;
+  isMulti?: boolean;
+  isClearable?: boolean;
+  onChange(event?: any): any;
+  onInputChange?(str: string, options?: any): any;
+  notOptions?: NotOptionsType;
+  error?: boolean;
+  required?: boolean;
+}
+
+/**
+ * Default select field including label. Select element is grafana/ui <Select />.
+ */
+const FormSelect: React.FC<FormSelectProps> = (props) => {
+  const {
+    label,
+    tooltip,
+    searchable = true,
+    disabled,
+    queryKeyword,
+    placeholder = '-',
+    labelWidth = 14,
+    inputWidth = 30,
+    className = '',
+    notOptions,
+    error,
+    required,
+    ...remainingProps
+  } = props;
+  const {
+    showNotCheckbox,
+    notCheckboxValue = false,
+    notCheckboxLabel = 'NOT',
+    onNotChange,
+    notCheckboxDisabled,
+  } = notOptions || {};
+  return (
+    <FormWrapper
+      error={error || (required && (props.isMulti ? !props.value?.length : !props.value))}
+      disabled={disabled}
+      stretch={!inputWidth}
+    >
+      <InlineFormLabel
+        className={queryKeyword ? `query-keyword ${className}` : className}
+        width={labelWidth}
+        tooltip={tooltip}
+      >
+        {label}
+      </InlineFormLabel>
+      <Select
+        prefix={notCheckboxValue ? '!' : null}
+        menuPlacement={'bottom'}
+        disabled={disabled}
+        width={inputWidth}
+        isSearchable={searchable}
+        placeholder={placeholder}
+        {...remainingProps}
+      />
+      {showNotCheckbox && (
+        <InlineFormLabel width={3.5}>
+          <Checkbox
+            className={'notCheckbox'}
+            value={notCheckboxValue}
+            label={notCheckboxLabel}
+            onChange={onNotChange}
+            disabled={notCheckboxDisabled}
+          />
+        </InlineFormLabel>
+      )}
+    </FormWrapper>
+  );
+};
+
+export default FormSelect;

--- a/src/components/FormWrapper.tsx
+++ b/src/components/FormWrapper.tsx
@@ -1,0 +1,27 @@
+// @ts-nocheck
+import React from 'react';
+
+interface WrapperProps {
+  disabled?: boolean;
+  stretch?: boolean;
+  children: any;
+  error?: boolean;
+}
+
+export default function FormWrapper(props: WrapperProps) {
+  const style: any = { display: 'flex' };
+
+  if (props.disabled) {
+    style.opacity = '0.4';
+    style.pointerEvents = 'none';
+  }
+  if (props.error) {
+    style['box-shadow'] = '0px 0px 5px red';
+  }
+
+  if (props.stretch) {
+    style.width = '100%';
+  }
+
+  return <div style={style}>{props.children}</div>;
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,13 +2,13 @@ import { DataSourcePlugin } from '@grafana/data';
 import { ConfigEditor } from './ConfigEditor';
 import { AlertmanagerDataSource } from './DataSource';
 import { QueryEditor } from './QueryEditor';
-import { CustomQuery, GenericOptions } from './types';
+import { EditorQuery, GenericOptions } from './types';
 
 class GenericAnnotationsQueryCtrl {
   static templateUrl = 'partials/annotations.editor.html';
 }
 
-export const plugin = new DataSourcePlugin<AlertmanagerDataSource, CustomQuery, GenericOptions>(AlertmanagerDataSource)
+export const plugin = new DataSourcePlugin<AlertmanagerDataSource, EditorQuery, GenericOptions>(AlertmanagerDataSource)
   .setAnnotationQueryCtrl(GenericAnnotationsQueryCtrl)
   .setConfigEditor(ConfigEditor)
   .setQueryEditor(QueryEditor);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,22 +1,23 @@
-import { DataQuery, DataQueryRequest, DataSourceJsonData } from '@grafana/data';
+import { DataQuery, DataSourceJsonData, QueryEditorProps } from '@grafana/data';
+import { AlertmanagerDataSource } from 'DataSource';
 
-export interface DataSourceOptions extends DataSourceJsonData {}
-
-export interface QueryRequest extends DataQueryRequest<CustomQuery> {
-  adhocFilters?: any[];
+export interface EditorQuery extends DataQuery {
+  scenario: string;
 }
 
-export interface CustomQuery extends DataQuery {
-  target?: string;
-  receiver: string;
-  filters: string;
-  active: boolean;
-  silenced: boolean;
-  inhibited: boolean;
-}
-
-export const defaultQuery: Partial<CustomQuery> = {
-  active: true,
-};
+export type QEditorProps = QueryEditorProps<AlertmanagerDataSource, EditorQuery>;
 
 export interface GenericOptions extends DataSourceJsonData {}
+
+export type OnChangeType = (key: string | object, value?: any, runQuery?: boolean) => void;
+
+export interface ScenarioProps<TsQuery extends EditorQuery>
+  extends QueryEditorProps<AlertmanagerDataSource, EditorQuery> {
+  query: TsQuery;
+  onFormChange: OnChangeType;
+}
+
+export const scenarios = {
+  alerts: 'alerts',
+  silences: 'silences',
+};


### PR DESCRIPTION
With this PR, I completely rewrite this plugin to add the possibility to have multiples possibles queries to execute and be able to choose the one we want through a `scenario` parameter.
Indeed, I introduced a new QueryEditor type called `EditorQuery`, it's extends `DataQuery` and have a scenario attribute.
All custom QueryEditors will now extends `EditorQuery` instead of `DataQuery` to have this new common attribute.

![Screenshot from 2022-05-23 15-41-44](https://user-images.githubusercontent.com/27230141/169832754-9f5d9f18-df29-4f1e-be31-245e780f703b.png)


On the query editor view of the plugin, a new selector will be available to choose which query we want to build. If user change this settings, the query editor will be updated for the new scenario with associated fields for the query config.
Atm, only one scenario is available which is the old one for alerts but a new one is coming to fetch silences rules from _Alertmanager_.

Before:
![Screenshot from 2022-05-23 15-34-19](https://user-images.githubusercontent.com/27230141/169831512-2c759399-b547-454b-9a1d-19f636e9536b.png)

Now:
![Screenshot from 2022-05-23 15-34-40](https://user-images.githubusercontent.com/27230141/169831540-a125af3f-42ea-47fc-8194-1aa55db30081.png)

By doing this change, I must rewrite almost all this plugin. So, I refactor others aspects of the code and updated some parts of it to more modern typescript.
